### PR TITLE
Fix broken link to Cicero slides

### DIFF
--- a/content/licensing.md
+++ b/content/licensing.md
@@ -122,7 +122,7 @@ Image unchanged from https://choosealicense.com/
 
 - Derivative work is free software and derivative work extends to the combined project
 
-If you would like to learn more check out [Software licensing and open source explained with cakes](https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/social-coding/master/licensing-and-cakes.md/)
+If you would like to learn more check out [Software licensing and open source explained with cakes](https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/social-coding/main/licensing-and-cakes.md/)
 
 ## Licencing and ownership
 


### PR DESCRIPTION
Due to the change of the branch "master" to "main", the link to "Software licensing and open source explained with cakes" was broken.