### PR TITLE
content/index: Remove duplicated TOC entries

### DIFF
--- a/content/index.rst
+++ b/content/index.rst
@@ -33,9 +33,6 @@ how software can be cited.
    :maxdepth: 1
    :caption: Reference
 
-   social_coding
-   licensing
-   software_citation
    quick-reference
    guide
 


### PR DESCRIPTION
- The lesson pages were both under 'The lesson" and "Reference"
- Review: automerge
