### PR TITLE
content/licensing: make the two questions `discussion` instead of `exercise`

### DIFF
--- a/content/licensing.md
+++ b/content/licensing.md
@@ -58,8 +58,8 @@ Is this derivative work? ["Distillery District 26"](https://www.flickr.com/photo
 
 ### Exercise: derivative work
 
-````{exercise} Licensing-1: What constitutes derivative work?
-This question 4 below can be used as a starting point and copied to the collaborative
+````{discussion} Licensing-1: What constitutes derivative work?
+This question 5 below can be used as a starting point and copied to the collaborative
 document or form input for an online poll:
 
 ```markdown
@@ -248,7 +248,7 @@ Services for sharing and collaborating on research data:
 
 ## Exercise: licensing situations
 
-````{exercise} Licensing-2: Consider some common licensing situations
+````{discussion} Licensing-2: Consider some common licensing situations
 1. What is the StackOverflow license for code you copy and paste?
 2. A journal requests that you release your software during publication. You have
    copied a portion of the code from another package, which you have forgotten.


### PR DESCRIPTION
- Matches their spirit more (and other pages have only discussions,
  not exercise blocks).
- They won't be in the exercise list, but anyway the other pages
  aren't there.
- The exercise list will then be empty (but actually I have a pending
  change that can allow us to put discussions there, so maybe we leave
  it for the time being?
- Review: consider the points above
