### PR TITLE
Removed RSD, is not data sharing

### DIFF
--- a/content/sharing-data.md
+++ b/content/sharing-data.md
@@ -23,7 +23,6 @@ platform and filter by country, content type, discipline, etc.
 - [The Open Science Framework](https://osf.io/): Gives free accounts for collaboration
   around files and other research artifacts. Each account can have up to 5 GB of files
   without any problem, and it remains private until you make it public.
-- [Research Software Directory](https://research-software-directory.org/)
 
 **Sweden:**
 - [ICOS for climate data](http://www.icos-sweden.se/)


### PR DESCRIPTION
RSD would belong to "software registration" / "software sharing", or more generically something like "service registration" or even "service FAIRification", together with the Research Software Ecosystem / Bio.tools, WorkflowHub, and other registries ...

... and maybe with packaging and containerisation systems, incl. Bioconda, Debian, Biocontainers (all these services which are not only "bio" anymore 🙈)